### PR TITLE
Use core libraries and remove dependencies

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -13,8 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jehiah/go-strftime"
-	"github.com/lunny/log"
+	"log"
 )
 
 type Command interface {
@@ -319,7 +318,7 @@ func (cmd commandEpsv) Execute(conn *Conn, param string) {
 
 	socket, err := newPassiveSocket(addr[:lastIdx], conn.PassivePort(), conn.logger, conn.tlsConfig)
 	if err != nil {
-		log.Error(err)
+		log.Println(err)
 		conn.writeMessage(425, "Data connection failed")
 		return
 	}
@@ -461,7 +460,7 @@ func (cmd commandMdtm) Execute(conn *Conn, param string) {
 	path := conn.buildPath(param)
 	stat, err := conn.driver.Stat(path)
 	if err == nil {
-		conn.writeMessage(213, strftime.Format("%Y%m%d%H%M%S", stat.ModTime()))
+		conn.writeMessage(213, stat.ModTime().Format("20060102150405"))
 	} else {
 		conn.writeMessage(450, "File not available")
 	}

--- a/listformatter.go
+++ b/listformatter.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-
-	"github.com/jehiah/go-strftime"
 )
 
 type listFormatter []FileInfo
@@ -30,7 +28,7 @@ func (formatter listFormatter) Detailed() []byte {
 		fmt.Fprintf(&buf, file.Mode().String())
 		fmt.Fprintf(&buf, " 1 %s %s ", file.Owner(), file.Group())
 		fmt.Fprintf(&buf, lpad(strconv.Itoa(int(file.Size())), 12))
-		fmt.Fprintf(&buf, strftime.Format(" %b %d %H:%M ", file.ModTime()))
+		fmt.Fprintf(&buf, file.ModTime().Format(" Jan _2 15:04"))
 		fmt.Fprintf(&buf, "%s\r\n", file.Name())
 	}
 	fmt.Fprintf(&buf, "\r\n")


### PR DESCRIPTION
I am not too much familiar with `lunny/log` and `jehiah/go-strftime` but it seems that we could drop them and rely on core libs.