### PR TITLE
Replace buildTCPString with JoinHostPort

### DIFF
--- a/server.go
+++ b/server.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"net"
 	"strconv"
-	"strings"
 )
 
 func Version() string {
@@ -133,7 +132,7 @@ func NewServer(opts *ServerOpts) *Server {
 	opts = serverOptsWithDefaults(opts)
 	s := new(Server)
 	s.ServerOpts = opts
-	s.listenTo = buildTCPString(opts.Hostname, opts.Port)
+	s.listenTo = net.JoinHostPort(opts.Hostname, strconv.Itoa(opts.Port))
 	s.name = opts.Name
 	s.driverFactory = opts.Factory
 	s.logger = newLogger("")
@@ -233,23 +232,4 @@ func (server *Server) Shutdown() error {
 	}
 	// server wasnt even started
 	return nil
-}
-
-func buildTCPString(hostname string, port int) (result string) {
-	if strings.Contains(hostname, ":") {
-		// ipv6
-		if port == 0 {
-			result = "[" + hostname + "]"
-		} else {
-			result = "[" + hostname + "]:" + strconv.Itoa(port)
-		}
-	} else {
-		// ipv4
-		if port == 0 {
-			result = hostname
-		} else {
-			result = hostname + ":" + strconv.Itoa(port)
-		}
-	}
-	return
 }

--- a/socket.go
+++ b/socket.go
@@ -3,7 +3,6 @@ package server
 import (
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -35,7 +34,7 @@ type ftpActiveSocket struct {
 }
 
 func newActiveSocket(remote string, port int, logger *Logger) (DataSocket, error) {
-	connectTo := buildTCPString(remote, port)
+	connectTo := net.JoinHostPort(remote, strconv.Itoa(port))
 
 	logger.Print("Opening active data connection to " + connectTo)
 
@@ -137,7 +136,7 @@ func (socket *ftpPassiveSocket) Close() error {
 }
 
 func (socket *ftpPassiveSocket) GoListenAndServe() (err error) {
-	laddr, err := net.ResolveTCPAddr("tcp", fmt.Sprintf("0.0.0.0:%d", socket.port))
+	laddr, err := net.ResolveTCPAddr("tcp", net.JoinHostPort("", strconv.Itoa(socket.port)))
 	if err != nil {
 		socket.logger.Print(err)
 		return


### PR DESCRIPTION
I think it's possible to drop the custom `buildTCPString` in favor of `net.JoinHostPort`.
