### PR TITLE
Send back a proper multiline response

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -161,7 +161,7 @@ func (cmd commandFeat) RequireAuth() bool {
 }
 
 var (
-	feats    = "211-Extensions supported:\n%s211 END"
+	feats    = "Extensions supported:\n%s"
 	featCmds = ""
 )
 
@@ -177,7 +177,7 @@ func (cmd commandFeat) Execute(conn *Conn, param string) {
 	if conn.tlsConfig != nil {
 		featCmds += " AUTH TLS\n PBSZ\n PROT\n"
 	}
-	conn.writeMessage(211, fmt.Sprintf(feats, featCmds))
+	conn.writeMessageMultiline(211, fmt.Sprintf(feats, featCmds))
 }
 
 // cmdCdup responds to the CDUP FTP command.

--- a/conn.go
+++ b/conn.go
@@ -180,6 +180,15 @@ func (conn *Conn) writeMessage(code int, message string) (wrote int, err error) 
 	return
 }
 
+// writeMessage will send a standard FTP response back to the client.
+func (conn *Conn) writeMessageMultiline(code int, message string) (wrote int, err error) {
+	conn.logger.PrintResponse(conn.sessionID, code, message)
+	line := fmt.Sprintf("%d-%s\r\n%d END\r\n", code, message, code)
+	wrote, err = conn.controlWriter.WriteString(line)
+	conn.controlWriter.Flush()
+	return
+}
+
 // buildPath takes a client supplied path or filename and generates a safe
 // absolute path within their account sandbox.
 //


### PR DESCRIPTION
Some clients asking for features will be expecting a standard multiline ftp response (according to section 4.2 in RFC949). This adds a multiline response method and rewrites the feature command to use it.