### PR TITLE
Implement Serve function to allow custom listeners

### DIFF
--- a/server.go
+++ b/server.go
@@ -215,7 +215,15 @@ func (server *Server) ListenAndServe() error {
 	sessionID := ""
 	server.logger.Printf(sessionID, "%s listening on %d", server.Name, server.Port)
 
-	server.listener = listener
+	return server.Serve(listener)
+}
+
+// Serve accepts connections on a given net.Listener and handles each
+// request in a new goroutine.
+//
+func (server *Server) Serve(l net.Listener) error {
+	server.listener = l
+	sessionID := ""
 	for {
 		tcpConn, err := server.listener.Accept()
 		if err != nil {


### PR DESCRIPTION
This change adda a Serve() function which allows the use of custom listeners to start a server. It's backwards-compatible and supports more use-cases in which a listener is created outside the ListenAndServe() function.