### PR TITLE
Improve shutdown behaviour

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -38,3 +38,11 @@ func (logger *StdLogger) PrintCommand(sessionId string, command string, params s
 func (logger *StdLogger) PrintResponse(sessionId string, code int, message string) {
 	log.Printf("%s < %d %s", sessionId, code, message)
 }
+
+// Silent logger, produces no output
+type DiscardLogger struct{}
+
+func (logger *DiscardLogger) Print(sessionId string, message interface{})                  {}
+func (logger *DiscardLogger) Printf(sessionId string, format string, v ...interface{})     {}
+func (logger *DiscardLogger) PrintCommand(sessionId string, command string, params string) {}
+func (logger *DiscardLogger) PrintResponse(sessionId string, code int, message string)     {}

--- a/server_test.go
+++ b/server_test.go
@@ -32,17 +32,18 @@ func runServer(t *testing.T, execute func()) {
 			Name:     "admin",
 			Password: "admin",
 		},
+		Logger: new(server.DiscardLogger),
 	}
 
-	server := server.NewServer(opt)
+	s := server.NewServer(opt)
 	go func() {
-		err := server.ListenAndServe()
-		assert.NoError(t, err)
+		err := s.ListenAndServe()
+		assert.EqualError(t, err, server.ErrServerClosed.Error())
 	}()
 
 	execute()
 
-	assert.NoError(t, server.Shutdown())
+	assert.NoError(t, s.Shutdown())
 }
 
 func TestConnect(t *testing.T) {
@@ -127,6 +128,7 @@ func TestServe(t *testing.T) {
 			Name:     "admin",
 			Password: "admin",
 		},
+		Logger: new(server.DiscardLogger),
 	}
 
 	// Start the listener
@@ -137,7 +139,7 @@ func TestServe(t *testing.T) {
 	s := server.NewServer(opt)
 	go func() {
 		err := s.Serve(l)
-		assert.NoError(t, err)
+		assert.EqualError(t, err, server.ErrServerClosed.Error())
 	}()
 
 	// Give server 0.5 seconds to get to the listening state


### PR DESCRIPTION
There are a few changes in here:

- It improves the shutdown behaviour, cleanly shutting down and no longer writing an error to the logs on Shutdown(). The way it's implemented means that `ErrServerClosed` is returned by Serve() and ListenAndServe() which is a little different from before and mirrors the http library. It could easily be changed to return `nil` on Shutdown() if that's preferable

- When Accept() fails for a client, it no longer takes down the whole server. `break` in the listening loop was changed to `continue`.

- Added a DiscardLogger to silence the tests, but since that may be useful to clients as well it was added to the library code. Can be moved to the tests easily if needed.

