### PR TITLE
Make sure we reset the append flag on RETR

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -691,6 +691,7 @@ func (cmd commandRetr) Execute(conn *Conn, param string) {
 	path := conn.buildPath(param)
 	defer func() {
 		conn.lastFilePos = 0
+		conn.appendData = false
 	}()
 	bytes, data, err := conn.driver.GetFile(path, conn.lastFilePos)
 	if err == nil {


### PR DESCRIPTION
Before this change "REST" followed by "RETR" would leave the append
flag set which means subsequent "STOR" commands append data when they
shouldn't.

And with this change the rclone ftp test suite passes against the example FTP server :-)