### PR TITLE
Fix formating for fmt.Sprint() messages

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -217,7 +217,7 @@ func (cmd commandCwd) Execute(conn *Conn, param string) {
 		conn.namePrefix = path
 		conn.writeMessage(250, "Directory changed to "+path)
 	} else {
-		conn.writeMessage(550, fmt.Sprint("Directory change to", path, "failed:", err))
+		conn.writeMessage(550, fmt.Sprint("Directory change to ", path, " failed: ", err))
 	}
 }
 
@@ -243,7 +243,7 @@ func (cmd commandDele) Execute(conn *Conn, param string) {
 	if err == nil {
 		conn.writeMessage(250, "File deleted")
 	} else {
-		conn.writeMessage(550, fmt.Sprint("File delete failed:", err))
+		conn.writeMessage(550, fmt.Sprint("File delete failed: ", err))
 	}
 }
 
@@ -471,7 +471,7 @@ func (cmd commandMkd) Execute(conn *Conn, param string) {
 	if err == nil {
 		conn.writeMessage(257, "Directory created")
 	} else {
-		conn.writeMessage(550, fmt.Sprint("Action not taken:", err))
+		conn.writeMessage(550, fmt.Sprint("Action not taken: ", err))
 	}
 }
 
@@ -726,7 +726,7 @@ func (cmd commandRest) Execute(conn *Conn, param string) {
 
 	conn.appendData = true
 
-	conn.writeMessage(350, fmt.Sprint("Start transfer from", conn.lastFilePos))
+	conn.writeMessage(350, fmt.Sprint("Start transfer from ", conn.lastFilePos))
 }
 
 // commandRnfr responds to the RNFR FTP command. It's the first of two commands
@@ -776,7 +776,7 @@ func (cmd commandRnto) Execute(conn *Conn, param string) {
 	if err == nil {
 		conn.writeMessage(250, "File renamed")
 	} else {
-		conn.writeMessage(550, fmt.Sprint("Action not taken", err))
+		conn.writeMessage(550, fmt.Sprint("Action not taken: ", err))
 	}
 }
 
@@ -802,7 +802,7 @@ func (cmd commandRmd) Execute(conn *Conn, param string) {
 	if err == nil {
 		conn.writeMessage(250, "Directory deleted")
 	} else {
-		conn.writeMessage(550, fmt.Sprint("Directory delete failed:", err))
+		conn.writeMessage(550, fmt.Sprint("Directory delete failed: ", err))
 	}
 }
 
@@ -1024,7 +1024,7 @@ func (cmd commandStor) Execute(conn *Conn, param string) {
 		msg := "OK, received " + strconv.Itoa(int(bytes)) + " bytes"
 		conn.writeMessage(226, msg)
 	} else {
-		conn.writeMessage(450, fmt.Sprint("error during transfer:", err))
+		conn.writeMessage(450, fmt.Sprint("error during transfer: ", err))
 	}
 }
 


### PR DESCRIPTION
In 18b6436b30 fmt.Sprintln was changed to fmt.Sprint.  However
fmt.Sprint formats its arguments slightly differently.  fmt.Sprintln
always adds spaces between arguments whereas the docs for fmt.Sprint
say, "Spaces are added between operands when neither is a string".

This commit fixes the spacing in all fmt.Sprint calls.

Sorry about this - I should have noticed this on the first commit.