### PR TITLE
Report errors to client when sending the RETR data

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -698,6 +698,9 @@ func (cmd commandRetr) Execute(conn *Conn, param string) {
 		defer data.Close()
 		conn.writeMessage(150, fmt.Sprintf("Data transfer starting %v bytes", bytes))
 		err = conn.sendOutofBandDataWriter(data)
+		if err != nil {
+			conn.writeMessage(551, "Error reading file")
+		}
 	} else {
 		conn.writeMessage(551, "File not available")
 	}


### PR DESCRIPTION
Before this change we ignored the errors returned from copying the
data to the socket.

This meant that if an error occurred the client would hang
indefinitely - the server thinking it had finished and the client
waiting for a response from the server.

After this change the server responds with a 551 message if the stream
breaks during the transfer.  This allows the client to pick up the
error and carry on.