### PR TITLE
Use constant-time compare for SimpleAuth

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -4,6 +4,10 @@
 
 package server
 
+import (
+	"crypto/subtle"
+)
+
 // Auth is an interface to auth your ftp user login.
 type Auth interface {
 	CheckPasswd(string, string) (bool, error)
@@ -21,8 +25,9 @@ type SimpleAuth struct {
 
 // CheckPasswd will check user's password
 func (a *SimpleAuth) CheckPasswd(name, pass string) (bool, error) {
-	if name != a.Name || pass != a.Password {
-		return false, nil
-	}
-	return true, nil
+	return constantTimeEquals(name, a.Name) && constantTimeEquals(pass, a.Password), nil
+}
+
+func constantTimeEquals(a, b string) bool {
+	return len(a) == len(b) && subtle.ConstantTimeCompare([]byte(a), []byte(b)) == 1
 }


### PR DESCRIPTION
This ensures that the password can't be guessed with a timing attack.


**References**
https://codahale.com/a-lesson-in-timing-attacks/
https://eprint.iacr.org/2011/232.pdf